### PR TITLE
tab2, tab3의 샘플 탬플릿 생성

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import googleapiclient.discovery
 import streamlit.components.v1 as components
 import utils
 
+# 유튜브 검색시 유튜브 리스트 저장
 class YoutubeVideo:
     youtube_list = list()
     def __init__(self,name,url,desc):
@@ -16,7 +17,7 @@ class YoutubeVideo:
     @classmethod
     def list_reset(cls):
         cls.youtube_list.clear()
-        
+
 YOUTUBE_API_KEY = "AIzaSyCt74iOovLdzJMGCfsCAW4nAssQB8LJWo0"
 
 # API client library
@@ -107,6 +108,7 @@ tab1, tab2, tab3 = st.tabs(["New Learning", "Uncomprehended", "Completed"])
 
 PREFIX_YOUTUBE_URL = "https://www.youtube.com/watch?v="
 
+#검색된 영상들
 with tab1:
     st.header("New Learning Videos")
 
@@ -126,7 +128,29 @@ with tab1:
 
                 st.write(f"**{title}**")
                 st.write(desc)
-                
+
+#이해 못한 영상과 개념
+with tab2:
+    st.header("Uncomprehended Videos")
+
+    for video in YoutubeVideo.youtube_list: #현재는 유튜브 리스트지만 추후 시청한 영상 리스트로 변경
+        if video.segment is not None:
+            video_column, info_column = st.columns([2, 3])
+            
+            with video_column:
+                st.video(video.url)  # Display the video
+            
+            with info_column:
+                st.write(f"**{video.name}**")
+                st.write(f"Segment: {video.segment}")
+
+#이해한 개념
+with tab3:
+    st.header("Completed Videos")
+
+    for video in YoutubeVideo.youtube_list: #현재는 유튜브 리스트지만 추후 시청한 영상 리스트로 변경
+        if video.segment is not None:
+            st.subheader(video.segment)
 
 with open('style.css', 'rt', encoding='UTF8') as f:
     st.markdown(f'<style>{f.read()}</style>', unsafe_allow_html=True )


### PR DESCRIPTION
tab2(Uncomprehended)와 tab3(Completed)를 간단하게 틀만 만들었습니다.
136, 151줄에 현재는 유튜브 검색 리스트를 들고 오고있지만 추후에 시청한 영상리스트로 변경하여 출력을 하면 됩니다.  

tab3는 현재 단계에서는 출력할 수 없기 때문에 tab2부분만 샘플 틀을 사진으로 찍어봤습니다. segment 부분에 추후 이해 못한 개념을 남길 것입니다.  
![image](https://github.com/datascience-labs/conex/assets/101037541/9b8497c1-7cda-4f78-910c-48d21bbeb6e7)
